### PR TITLE
Packets

### DIFF
--- a/PACKETS.md
+++ b/PACKETS.md
@@ -74,10 +74,17 @@ Chaque paquet comprend un **seqId** qui permet de rapidement identifier la natur
 {
   "seqId": 3,
   "data": {
-    "positions": [
+    "firstSymmetryPositions": [
       {
         "x": 140,
         "y": 340,
+        "type": "s"
+      }
+    ],
+    "secondSymmetryPositions": [
+      {
+        "x": 340,
+        "y": 140,
         "type": "s"
       }
     ]
@@ -97,7 +104,8 @@ Chaque paquet comprend un **seqId** qui permet de rapidement identifier la natur
 
 ```json
 {
-  "seqId": 5
+  "seqId": 5,
+  "symmetry": 0
 }
 ```
 


### PR DESCRIPTION
Le bouton `Display the rich diff` va être utile. Si on à des problèmes de performances je vais convertir ça en en un format de suite de **x** bytes. Les mappers dans l'app devraient être assez simples. J'ai syncé avec Marc pour les paquets de la dernière section, il se peut que le format soit légèrement différent.