### PR TITLE
Close connection and save session on close

### DIFF
--- a/app/pods/components/aa-title-bar/component.js
+++ b/app/pods/components/aa-title-bar/component.js
@@ -8,6 +8,7 @@ const {remote} = requireNode('electron');
 
 export default Component.extend({
   connection: service('connection'),
+  session: service('session'),
 
   didRender() {
     this._super(...arguments);
@@ -32,6 +33,7 @@ export default Component.extend({
 
     $('.close').on('click', () => {
       run(() => {
+        this.get('session').dumpSessionInFile();
         this.get('connection').disconnect(config.APP.WEBSOCKET_ADDRESS);
         remote.app.quit();
       });

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -2,6 +2,8 @@ import Service, {inject as service} from '@ember/service';
 import {computed} from '@ember/object';
 import config from 'adaptone-front/config/environment';
 
+const {ipcRenderer} = requireNode('electron');
+
 export default Service.extend({
   fileSystem: service('file-system'),
 
@@ -15,6 +17,11 @@ export default Service.extend({
 
     set(_, configuration) {
       localStorage.setItem(config.APP.LOCAL_STORAGE.SESSION_NAMESPACE, JSON.stringify(configuration));
+
+      ipcRenderer.on('save-application-session', () => {
+        const config = this.get('configuration');
+        this.get('fileSystem').editConfiguration(config);
+      });
 
       return configuration;
     }

--- a/ember-electron/main.js
+++ b/ember-electron/main.js
@@ -65,6 +65,11 @@ app.on('ready', () => {
   mainWindow.on('closed', () => {
     mainWindow = null;
   });
+
+  mainWindow.on('close', (e) => {
+    mainWindow.webContents.send('save-application-session');
+    mainWindow.webContents.send('close-connection');
+  });
 });
 
 // Handle an unhandled error in the main thread


### PR DESCRIPTION
Quand l'application est fermée comme du monde, on ferme le socket de la connexion et on enregistre la session dans le fichier. Quand l'application n'est pas fermée comme du monde, on fait la même chose, mais c'est Electron qui doit nous notifier que c'est arrivé. C'est impossible de gérer le cas ou le process se fait kill.