### PR TITLE
Introduce input volumes page for auxiliary outputs

### DIFF
--- a/app/constants/channels.js
+++ b/app/constants/channels.js
@@ -312,7 +312,7 @@ const auxInputs = [
     data: {
       channelId: 4,
       auxiliaryChannelId: 1,
-      isAuxiliaryInput : true,
+      isAuxiliaryInput: true,
       channelName: 'Aux 1 input 3',
       gain: 3.00,
       isMuted: false,
@@ -323,7 +323,7 @@ const auxInputs = [
     data: {
       channelId: 5,
       auxiliaryChannelId: 1,
-      isAuxiliaryInput : true,
+      isAuxiliaryInput: true,
       channelName: 'Aux 1 input 4',
       gain: 3.00,
       isMuted: false,

--- a/app/pods/components/aa-channel-details/component.js
+++ b/app/pods/components/aa-channel-details/component.js
@@ -24,6 +24,9 @@ export default Component.extend({
   userChannelVolume: 0,
   userChannelGain: 0,
 
+  isEqVisible: true,
+  isInputVolumeVisible: false,
+
   isAuxiliaryInput: computed('channel.data.isAuxiliaryInput', function() {
     if (this.get('channel').data.isAuxiliaryInput === true) return true;
 
@@ -118,6 +121,31 @@ export default Component.extend({
 
     saveConfiguration() {
       this.get('session').dumpSessionInFile();
+    },
+
+    onEqTabClick() {
+      this.set('isInputVolumeVisible', false);
+      this.set('isEqVisible', true);
+    },
+
+    onInputVolumeTabClick() {
+      this.set('isEqVisible', false);
+      this.set('isInputVolumeVisible', true);
+    },
+
+    onInputChannelMuteChange(_) {
+      this._updateSessionConfiguration();
+      // Handle channel mute change here
+    },
+
+    onInputChannelSoloChange(_) {
+      this._updateSessionConfiguration();
+      // Handle channel solo change here
+    },
+
+    onInputChannelVolumeChange(_) {
+      this._updateSessionConfiguration();
+      // Handle volume change here
     }
   },
 

--- a/app/pods/components/aa-channel-details/styles.scss
+++ b/app/pods/components/aa-channel-details/styles.scss
@@ -20,9 +20,9 @@
   background-color: $big-stone;
   color: #fff;
   font-family: $text-font-semibold;
-  font-size: 24px;
+  font-size: 18px;
   border-radius: 0 4px 4px 0;
-  padding: 2px 8px;
+  padding: 2px 12px;
   margin-right: 15px;
 }
 
@@ -74,4 +74,30 @@
   text-align: center;
   padding: 6px 20px;
   margin-right: 5px;
+}
+
+.tabs-container {
+  display: flex;
+  padding: 5px 20px;
+}
+
+.tab {
+  color: $big-stone;
+  border-radius: 5px 5px 0 0;
+  font-family: $text-font-semibold;
+  font-size: 18px;
+  padding: 6px 20px;
+  transition: 0.3s ease;
+  transition-property: background-color, color;
+
+  &.active {
+    background-color: $big-stone;
+    color: #fff;
+  }
+}
+
+.input-volumes-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 100px;
 }

--- a/app/pods/components/aa-channel-details/template.hbs
+++ b/app/pods/components/aa-channel-details/template.hbs
@@ -1,64 +1,98 @@
-<div class="graph-container">
-  <div class="header">
-    <div class="channel-name">
-      {{this.channel.data.channelName}}
+{{#if this.isAuxiliaryOutput}}
+  <div class="tabs-container">
+    <div
+      class="tab {{if this.isEqVisible 'active'}}"
+      onClick={{action 'onEqTabClick'}}
+    >
+      {{t 'channel-details.tabs.eq'}}
     </div>
 
-    {{aa-toggle
-      leftValue=(t 'channel-details.graphic')
-      rightValue=(t 'channel-details.parametric')
-      isActive=this.isParametric
-    }}
-
-      <button
-        class="save-button"
-        onClick={{action "saveConfiguration"}}
-      >
-        {{t 'console.save'}}
-      </button>
+    <div
+      class="tab {{if this.isInputVolumeVisible 'active'}}"
+      onClick={{action 'onInputVolumeTabClick'}}
+    >
+      {{t 'channel-details.tabs.input-volumes'}}
+    </div>
   </div>
+{{/if}}
 
-  <div class="graph">
-    {{aa-eq-graph
-      isParametric=this.isParametric
-      channelInfos=this.channel
-      parametricEqValues=this.parametricEqGraphValues
-      graphicEqValues=this.graphicEqGraphValues
-    }}
-  </div>
-</div>
+{{#if this.isEqVisible}}
+  <div class="graph-container">
+    <div class="header">
+      <div class="channel-name">
+        {{this.channel.data.channelName}}
+      </div>
 
-
-<div class="eq-container">
-  {{#unless this.isAuxiliaryOutput}}
-    {{#unless this.isMasterOutput}}
-      {{aa-gain
-        class="gain-container"
-        gain=this.channel.data.gain
-        inputAfterGain=this.inputAfterGain
-        inputAfterEq=this.inputAfterEq
-        isMute=this.channel.data.isMuted
-        isSolo=this.channel.data.isSolo
-        onGainChange=(action "onGainChange")
-        onIsMutedChange=(action "onIsMutedChange")
-        onIsSoloChange=(action "onIsSoloChange")
+      {{aa-toggle
+        leftValue=(t 'channel-details.graphic')
+        rightValue=(t 'channel-details.parametric')
+        isActive=this.isParametric
       }}
-    {{/unless}}
-  {{/unless}}
 
-  {{aa-eq
-    auxiliaryChannelId=this.channel.data.auxiliaryChannelId
-    channelId=this.channel.data.channelId
-    isParametric=this.isParametric
-    parametricFilters=this.channel.data.paramEq
-    graphicFilters=this.channel.data.graphEq
-    parametricEqGraphValues=this.parametricEqGraphValues
-    graphicEqGraphValues=this.graphicEqGraphValues
-    isMasterOutput=this.isMasterOutput
-    isAuxiliaryOutput=this.isAuxiliaryOutput
-    onEqChange=(action "onEqChange")
-  }}
-</div>
+        <button
+          class="save-button"
+          onClick={{action "saveConfiguration"}}
+        >
+          {{t 'console.save'}}
+        </button>
+    </div>
+
+    <div class="graph">
+      {{aa-eq-graph
+        isParametric=this.isParametric
+        channelInfos=this.channel
+        parametricEqValues=this.parametricEqGraphValues
+        graphicEqValues=this.graphicEqGraphValues
+      }}
+    </div>
+  </div>
+
+
+  <div class="eq-container">
+    {{#unless this.isAuxiliaryOutput}}
+      {{#unless this.isMasterOutput}}
+        {{aa-gain
+          class="gain-container"
+          gain=this.channel.data.gain
+          inputAfterGain=this.inputAfterGain
+          inputAfterEq=this.inputAfterEq
+          isMute=this.channel.data.isMuted
+          isSolo=this.channel.data.isSolo
+          onGainChange=(action "onGainChange")
+          onIsMutedChange=(action "onIsMutedChange")
+          onIsSoloChange=(action "onIsSoloChange")
+        }}
+      {{/unless}}
+    {{/unless}}
+
+    {{aa-eq
+      auxiliaryChannelId=this.channel.data.auxiliaryChannelId
+      channelId=this.channel.data.channelId
+      isParametric=this.isParametric
+      parametricFilters=this.channel.data.paramEq
+      graphicFilters=this.channel.data.graphEq
+      parametricEqGraphValues=this.parametricEqGraphValues
+      graphicEqGraphValues=this.graphicEqGraphValues
+      isMasterOutput=this.isMasterOutput
+      isAuxiliaryOutput=this.isAuxiliaryOutput
+      onEqChange=(action "onEqChange")
+    }}
+  </div>
+{{/if}}
+
+{{#if this.isInputVolumeVisible}}
+  <div class="input-volumes-container">
+    {{#each-in this.channel.data.inputs as |index channel|}}
+      {{aa-channel
+        channel=channel
+        onChannelMuteChange=(action "onInputChannelMuteChange" channel.data)
+        onChannelSoloChange=(action "onInputChannelSoloChange" channel.data)
+        onVolumeChange=(action "onInputChannelVolumeChange" channel.data)
+        isOutput=false
+      }}
+    {{/each-in}}
+  </div>
+{{/if}}
 
 {{#link-to 'console'}}
   {{inline-svg "assets/images/arrow-icon.svg" class="arrow-icon"}}

--- a/app/pods/components/aa-knob/styles.scss
+++ b/app/pods/components/aa-knob/styles.scss
@@ -3,7 +3,7 @@
 & {
   display: flex;
   flex-direction: column;
-  margin: 20px;
+  margin: 5px 20px;
   width: 100px;
 }
 

--- a/app/pods/components/aa-toggle/styles.scss
+++ b/app/pods/components/aa-toggle/styles.scss
@@ -4,7 +4,8 @@
   display: flex;
   color: $big-stone;
   font-family: $text-font-semibold;
-  font-size: 22px;
+  font-size: 16px;
+  margin-top: 5px;
 }
 
 $width: 40px;
@@ -50,7 +51,7 @@ input[type='checkbox'] {
 
 .card {
   display: inline-block;
-  margin: (($height * 1.4 - $height) / 2) + 5px;
+  margin: ($height / 4) (($height * 1.4 - $height) / 2) + 5px (($height * 1.4 - $height) / 2) + 5px;
   width: $width;
   height: $height;
   text-align: center;

--- a/translations/fr-ca.yaml
+++ b/translations/fr-ca.yaml
@@ -56,6 +56,9 @@ eq:
 channel-details:
   graphic: Graph
   parametric: Param
+  tabs:
+    eq: EQ
+    input-volumes: Volumes
 console:
   save: Sauvegarder
 gain:


### PR DESCRIPTION
Un simple ajout d'onglets pour choisir entre les volumes ou l'EQ d'une sortie auxiliaire.
J'ai fait quelques ajustements CSS aussi.

![Capture](https://user-images.githubusercontent.com/22030235/65393161-49166180-dd4b-11e9-8c39-f42ce6480f6c.PNG)
![Capture2](https://user-images.githubusercontent.com/22030235/65393162-4a478e80-dd4b-11e9-9ce2-27490b55b50b.PNG)

Les événements sont prêts à être bindés, je laisse ça pour la tâche événements manquants si jamais.
