### PR TITLE
Send auxiliaryChannelId on channel gain change

### DIFF
--- a/app/pods/components/aa-channel/component.js
+++ b/app/pods/components/aa-channel/component.js
@@ -53,6 +53,7 @@ export default Component.extend({
       seqId,
       data: {
         channelId,
+        auxiliaryChannelId: channel.data.auxiliaryChannelId || null,
         gain: formattedGain
       }
     };


### PR DESCRIPTION
On envoyait pas le auxiliaryChannelId sur le changement de gain d'un channel. Maintenant, oui.