### PR TITLE
Fix slider write in session on mute

### DIFF
--- a/app/pods/components/aa-channel-details/component.js
+++ b/app/pods/components/aa-channel-details/component.js
@@ -7,6 +7,7 @@ import {set} from '@ember/object';
 import SequenceIds from 'adaptone-front/constants/sequence-ids';
 
 const DEBOUNCE_TIME = 20;
+const WRITE_IN_SESSION_DEBOUNCE_TIME = 20;
 const MAX_GAIN_VALUE = 12;
 const DECIBEL_CONVERT = 10;
 const DECIBEL_FACTOR = 20;
@@ -120,7 +121,7 @@ export default Component.extend({
     },
 
     onGainChange(value) {
-      this._updateSessionConfiguration();
+      debounce(this, this._updateSessionConfiguration, WRITE_IN_SESSION_DEBOUNCE_TIME);
 
       const ratioGain = Math.pow(DECIBEL_CONVERT, value / DECIBEL_FACTOR);
 

--- a/app/pods/components/aa-channel/component.js
+++ b/app/pods/components/aa-channel/component.js
@@ -6,7 +6,7 @@ import {debounce} from '@ember/runloop';
 import SequenceIds from 'adaptone-front/constants/sequence-ids';
 
 const DEBOUNCE_TIME = 20;
-const WRITE_IN_SESSION_DEBOUNCE_TIME = 50;
+const WRITE_IN_SESSION_DEBOUNCE_TIME = 20;
 const GAIN_MAX_VALUE = 100;
 
 export default Component.extend({
@@ -45,6 +45,8 @@ export default Component.extend({
   }),
 
   channelGainChanged: observer('gainValue', function() {
+    debounce(this, this.onGainChange, WRITE_IN_SESSION_DEBOUNCE_TIME);
+
     const {channel, masterInputs, gainValue} = this.getProperties('channel', 'masterInputs', 'gainValue');
     const seqId = this._getGainSequenceId();
     const channelId = channel.data.channelId;
@@ -70,7 +72,6 @@ export default Component.extend({
       }
     };
 
-    debounce(this, this.onGainChange, WRITE_IN_SESSION_DEBOUNCE_TIME);
     debounce(this.get('connection'), this.get('connection').sendMessage, message, DEBOUNCE_TIME);
   }),
 


### PR DESCRIPTION
On ne _debounçait_ pas la mise à jour de session dans le `channel-details`.
On ne sauvegardait pas la config en session quand un channel était sur mute ou solo. 👀 