### PR TITLE
Remove spectrum chart series for outputs

### DIFF
--- a/app/pods/components/aa-eq-graph/component.js
+++ b/app/pods/components/aa-eq-graph/component.js
@@ -208,16 +208,19 @@ export default Component.extend({
       {
         name: this.intl.t('eq-graph.series.eq-gain'),
         data: eqGains
-      },
-      {
+      }
+    ];
+
+    if (!this.get('isOutput')) {
+      chartData.push({
         name: this.intl.t('eq-graph.series.channel-spectrums'),
         data: channelSpectrums
       },
       {
         name: this.intl.t('eq-graph.series.channels-spectrums'),
         data: addedChannelsSpectrums
-      }
-    ];
+      });
+    }
 
     this.set('chartOptions', chartOptions);
     this.set('chartData', chartData);

--- a/app/pods/components/aa-heat-map/component.js
+++ b/app/pods/components/aa-heat-map/component.js
@@ -35,7 +35,6 @@ export default PositionsMap.extend({
   },
 
   willDestroyElement() {
-    this.get('packetDispatcher').off('error-rates');
     $(window).off('resize');
   },
 


### PR DESCRIPTION
Rien de ben compliqué.

J'ai aussi ôté `this.get('packetDispatcher').off('error-rates');` du component `aa-heat-map`. Ça faisait crash l'app car on a pas de `this.get('packetDispatcher').on('error-rates');` dans ce component là.