### PR TITLE
Fix app crash when transitioning from symmetry to console

### DIFF
--- a/app/pods/components/aa-probe-positions/component.js
+++ b/app/pods/components/aa-probe-positions/component.js
@@ -160,7 +160,7 @@ export default Component.extend({
 
       this.get('fileSystem').editConfiguration(configuration);
       this.get('session').set('configuration', configuration);
-      this.router.transitionTo('console');
+      this.get('router').transitionTo('console');
 
       // This code would be used if we had an optimization routine in place, this is not the case currently
       /*

--- a/app/pods/components/aa-toggle/template.hbs
+++ b/app/pods/components/aa-toggle/template.hbs
@@ -2,7 +2,7 @@
 
 <div class="card">
   <label for="switch">
-    {{input type="checkbox" id="switch" checked=isActive}}
+    {{input type="checkbox" checked=isActive}}
       <span class="switch" onClick={{action "onClick"}}></span>
       <span class="toggle" onClick={{action "onClick"}}></span>
   </label>


### PR DESCRIPTION
Les deux toggle apparaissaient en même temps dans la page avec le même id, donc Ember faisait crash le rendering du component.